### PR TITLE
Update this to use new eodhp-utils features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,5 @@ takeover: venv
 		kubectl port-forward service/pulsar-proxy -n pulsar 6650:6650 &\
 		S3_BUCKET=spdx-public-eodhp-dev ./venv/bin/python3 -m annotations_ingester --pulsar-url pulsar://localhost:6650 -vv -t\
 	'
+krestart:
+	kubectl rollout restart deployment.apps/annotations-ingester -n rc

--- a/Makefile
+++ b/Makefile
@@ -56,3 +56,10 @@ venv:
 	curl -o .pre-commit-config.yaml https://raw.githubusercontent.com/EO-DataHub/github-actions/main/.pre-commit-config-python.yaml
 
 setup: venv requirements .make-venv-installed .git/hooks/pre-commit
+
+takeover: venv
+	bash -c '\
+		trap "trap - SIGTERM && kill -- -$$$$" SIGINT SIGTERM EXIT;\
+		kubectl port-forward service/pulsar-proxy -n pulsar 6650:6650 &\
+		S3_BUCKET=spdx-public-eodhp-dev ./venv/bin/python3 -m annotations_ingester --pulsar-url pulsar://localhost:6650 -vv -t\
+	'

--- a/annotations_ingester/__main__.py
+++ b/annotations_ingester/__main__.py
@@ -1,26 +1,32 @@
-import logging
 import os
 
-import boto3
-from eodhp_utils.runner import run
+import click
+from eodhp_utils.runner import (
+    get_boto3_session,
+    log_component_version,
+    run,
+    setup_logging,
+)
 
 from annotations_ingester.annotations_generator import AnnotationsMessager
 from annotations_ingester.dataset_dcat_generator import DatasetDCATMessager
 
 
-def main():
+@click.command
+@click.option("--takeover", "-t", is_flag=True, default=False, help="Run in takeover mode.")
+@click.option("-v", "--verbose", count=True)
+@click.option("--pulsar-url")
+def cli(takeover: bool, verbose: int, pulsar_url=None):
+    setup_logging(verbosity=verbose)
+    log_component_version("annotations_ingester")
+
     if os.getenv("TOPIC"):
         identifier = "_" + os.getenv("TOPIC")
     else:
         identifier = ""
 
-    session = boto3.session.Session(
-        aws_access_key_id=os.environ.get("AWS_ACCESS_KEY"),
-        aws_secret_access_key=os.environ.get("AWS_SECRET_ACCESS_KEY"),
-    )
+    session = get_boto3_session()
     s3_client = session.client("s3")
-
-    logging.basicConfig(level=logging.DEBUG, format="%(asctime)s - %(levelname)s - %(message)s")
 
     destination_bucket = os.environ.get("S3_BUCKET")
 
@@ -35,8 +41,10 @@ def main():
             f"transformed{identifier}": datasets_messager,
         },
         "annotations-ingester",
+        takeover_mode=takeover,
+        pulsar_url=pulsar_url,
     )
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@
 
 [project]
 name = "annotations-ingester"
-version = "0.1.0"
+# Version is calculated by setuptools-git-versioning from the Git tag.
+dynamic = ["version"]
 description = "Populates annotations service with annotations and with a DCAT representation of the catalogue"
 readme = "README.md"
 
@@ -68,7 +69,8 @@ dependencies = [
     "botocore",
     "rdflib",
     "pystac",
-    "eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.3",
+    "click",
+    "eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@EODHP-643-s3-client",
 ]
 
 # List additional groups of dependencies here (e.g. development
@@ -111,8 +113,11 @@ changelog = "https://github.com/EO-DataHub/annotations-ingester/blob/main/CHANGE
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=69.0.0", "wheel"]
+requires = ["setuptools>=69.0.0", "wheel", "setuptools-git-versioning>=2.0,<3"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools-git-versioning]
+enabled = true
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,11 +28,12 @@ cfgv==3.4.0
     # via pre-commit
 click==8.1.7
     # via
+    #   annotations-ingester (pyproject.toml)
     #   black
     #   pip-tools
 distlib==0.3.9
     # via virtualenv
-eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.3
+eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@EODHP-643-s3-client
     # via annotations-ingester (pyproject.toml)
 execnet==2.1.1
     # via pytest-xdist

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,9 @@ botocore==1.35.58
     #   s3transfer
 certifi==2024.8.30
     # via pulsar-client
-eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@v0.1.3
+click==8.1.7
+    # via annotations-ingester (pyproject.toml)
+eodhp-utils @ git+https://github.com/UKEODHP/eodhp-utils@EODHP-643-s3-client
     # via annotations-ingester (pyproject.toml)
 jmespath==1.0.1
     # via


### PR DESCRIPTION
The annotations-ingester can now support takeover mode, defers connecting to AWS to eodhp-utils and uses the common logging setup.

It now also auto-generates its version number.

I'll update the `@EODHP-643-s3-client` to a real version once the eodhp-utils change it depends on has been merged.